### PR TITLE
Add remote MongoDB connection example to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -235,6 +235,18 @@ Customer[id=51df1b0a3004cb49c50210f9, firstName='Bob', lastName='Smith']
 ----
 ====
 
+== Connecting to a Remote MongoDB Server
+
+If your MongoDB instance is hosted on a different machine or server, you can configure the connection in `application.properties` using:
+
+[source,properties]
+----
+spring.data.mongodb.uri=mongodb://username:password@192.168.1.100:27017/mydatabase
+----
+
+Replace `username`, `password`, `192.168.1.100`, `27017`, and `mydatabase` with your actual values.
+
+
 == Summary
 
 Congratulations! You set up a MongoDB server and wrote a simple application that uses


### PR DESCRIPTION
**Summary**
This PR adds a short section in the README.adoc showing how to connect to a remote MongoDB server using the spring.data.mongodb.uri property.

**Why**
It helps users who are not running MongoDB locally and addresses the need mentioned in Issue #43.

**Fix**
Added a sample connection string with placeholders and a brief explanation.

Closes #43